### PR TITLE
Balance Display 

### DIFF
--- a/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
+++ b/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
@@ -1,6 +1,8 @@
 package com.ammonium.adminshop.money;
 
 import com.ammonium.adminshop.AdminShop;
+import com.ammonium.adminshop.setup.Config;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -30,7 +32,7 @@ public class BalanceDisplay {
 
     @SubscribeEvent
     public static void onTick(TickEvent.ClientTickEvent event) {
-        //if (!Config.emcDisplay.get()) return;
+        if (!Config.balanceDisplay.get()) return;
         LocalPlayer player = getPlayer();
         tick++;
         if (event.phase == TickEvent.Phase.END && player != null && tick >= 20) {
@@ -52,13 +54,13 @@ public class BalanceDisplay {
 
     @SubscribeEvent
     public static void clientDisconnect(ClientPlayerNetworkEvent.LoggingOut event) {
-        //if (!Config.emcDisplay.get()) return;
+        if (!Config.balanceDisplay.get()) return;
         reset();
     }
 
     @SubscribeEvent
     public static void onRenderGUI(CustomizeGuiOverlayEvent.DebugText  event) {
-        //if (!Config.emcDisplay.get()) return;
+        if (!Config.balanceDisplay.get()) return;
         long avg = history[0] + history[1];
         String str = String.valueOf(balance);
         if (avg != 0) str += " " + (avg > 0 ? (ChatFormatting.GREEN + "+") : (ChatFormatting.RED)) + avg + "/s";

--- a/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
+++ b/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
@@ -1,0 +1,69 @@
+package com.ammonium.adminshop.money;
+
+import com.ammonium.adminshop.AdminShop;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nullable;
+
+@OnlyIn(Dist.CLIENT)
+@Mod.EventBusSubscriber(modid = AdminShop.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+public class BalanceDisplay {
+    private static long balance = 0;
+    private static final long[] history = new long[]{0, 0};
+    private static long lastBalance = 0;
+    private static int tick = 0;
+
+    private static @Nullable
+    LocalPlayer getPlayer() {
+        return Minecraft.getInstance().player;
+    }
+
+    @SubscribeEvent
+    public static void onTick(TickEvent.ClientTickEvent event) {
+        //if (!Config.emcDisplay.get()) return;
+        LocalPlayer player = getPlayer();
+        tick++;
+        if (event.phase == TickEvent.Phase.END && player != null && tick >= 20) {
+            tick = 0;
+            //BankAccount selectedAccount = getBankAccount();
+            //Pair<String, Integer> selectedAccountInfo = Pair.of(selectedAccount.getOwner(), selectedAccount.getId());
+            //For testing purposes
+            Pair<String, Integer> selectedAccountInfo = Pair.of("", 1);
+            balance = ClientLocalData.getMoney(selectedAccountInfo);
+            history[1] = history[0];
+            history[0] = balance - lastBalance;
+            lastBalance = balance;
+        }
+    }
+
+    private static void reset() {
+        balance = lastBalance = 0;
+        tick = 0;
+    }
+
+    @SubscribeEvent
+    public static void clientDisconnect(ClientPlayerNetworkEvent.LoggingOut event) {
+        //if (!Config.emcDisplay.get()) return;
+        reset();
+    }
+
+    @SubscribeEvent
+    public static void onRenderGUI(CustomizeGuiOverlayEvent.DebugText  event) {
+        //if (!Config.emcDisplay.get()) return;
+        long avg = history[0] + history[1];
+        String str = String.valueOf(balance);
+        if (avg != 0) str += " " + (avg > 0 ? (ChatFormatting.GREEN + "+") : (ChatFormatting.RED)) + avg + "/s";
+        event.getLeft().add(String.format("Balance: %s", str));
+    }
+
+}

--- a/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
+++ b/src/main/java/com/ammonium/adminshop/money/BalanceDisplay.java
@@ -35,10 +35,9 @@ public class BalanceDisplay {
         tick++;
         if (event.phase == TickEvent.Phase.END && player != null && tick >= 20) {
             tick = 0;
-            //BankAccount selectedAccount = getBankAccount();
-            //Pair<String, Integer> selectedAccountInfo = Pair.of(selectedAccount.getOwner(), selectedAccount.getId());
-            //For testing purposes
-            Pair<String, Integer> selectedAccountInfo = Pair.of("", 1);
+            String playerUUID = player.getStringUUID();
+            ClientLocalData.sortUsableAccounts();
+            Pair<String, Integer> selectedAccountInfo = Pair.of(playerUUID, 1);
             balance = ClientLocalData.getMoney(selectedAccountInfo);
             history[1] = history[0];
             history[0] = balance - lastBalance;

--- a/src/main/java/com/ammonium/adminshop/setup/Config.java
+++ b/src/main/java/com/ammonium/adminshop/setup/Config.java
@@ -8,6 +8,7 @@ public class Config {
 
     public static ForgeConfigSpec.LongValue STARTING_MONEY;
     public static String SHOP_CONTENTS;
+    public static ForgeConfigSpec.BooleanValue balanceDisplay;
 
     public static void register(){
         ForgeConfigSpec.Builder config = new ForgeConfigSpec.Builder();
@@ -23,6 +24,10 @@ public class Config {
         STARTING_MONEY = config
                 .comment("Amount of money each player starts with. Must be a whole number.")
                 .defineInRange("starting_money", 100, 0, Long.MAX_VALUE);
+
+        balanceDisplay = config
+                .comment("Displays your current balance and gained balance per second in the top left corner")
+                .define("Enabled", true);
         config.pop();
     }
 }


### PR DESCRIPTION
Add a balance display in corner of screen, like the one used in ProjectExpansion (see below). Currently partly finished.

![emc_display](https://github.com/sanyaysan/AdminShopOverhauled/assets/58048019/689e1737-efc9-4039-bcc0-7e771c7df1db)

TODO: 
- [x] Get player balance
- [ ] Respect account switch
- [ ] Use [formatting](https://github.com/DonovanDMC/ProjectExpansion/blob/82dbc8f4ec3db4cfc822709ddffe03bc1fba7a1a/src/main/java/cool/furry/mc/forge/projectexpansion/util/EMCFormat.java) (M, B, T, etc)
- [x] Add config options

based on: [EMCDisplay](https://github.com/DonovanDMC/ProjectExpansion/blob/82dbc8f4ec3db4cfc822709ddffe03bc1fba7a1a/src/main/java/cool/furry/mc/forge/projectexpansion/gui/EMCDisplay.java)